### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.1+8] - May 23, 2023
+
+* Automated dependency updates
+
+
 ## [3.0.1+7] - May 9, 2023
 
 * Automated dependency updates
@@ -81,6 +86,7 @@ Updated to `websafe_svg` 3.0.0 which supports different attributes.
 ## [1.0.0] - November 13th, 2021
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_plugin_svg'
 description: 'A plugin to the JSON Dynamic Widget to provide SVG support to the widgets'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget_plugin_svg'
-version: '3.0.1+7'
+version: '3.0.1+8'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -15,7 +15,7 @@ dependencies:
   child_builder: '^2.0.1'
   flutter: 
     sdk: 'flutter'
-  flutter_svg: '^2.0.5'
+  flutter_svg: '^2.0.6'
   json_class: '^2.2.1+3'
   json_dynamic_widget: '^6.0.5+1'
   json_theme: '^5.0.2+6'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `flutter_svg`: 2.0.5 --> 2.0.6


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ Note: The Google Privacy Policy describes how data is handled in this      ║
  ║ service.                                                                   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
The Flutter CLI developer tool uses Google Analytics to report usage and diagnostic data
along with package dependencies, and crash reporting to send basic crash reports.
This data is used to help improve the Dart platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter --disable-telemetry.
If you opt out of telemetry, an opt-out event will be sent,
and then no further information will be sent.
This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).



Because json_dynamic_widget >=6.0.5+1 depends on template_expressions ^3.0.2+1 which depends on petitparser 5.1.0, json_dynamic_widget >=6.0.5+1 requires petitparser 5.1.0.
And because xml >=6.3.0 depends on petitparser ^5.4.0, json_dynamic_widget >=6.0.5+1 is incompatible with xml >=6.3.0.
And because flutter_svg >=2.0.6 depends on vector_graphics_compiler ^1.1.6 which depends on xml ^6.3.0, json_dynamic_widget >=6.0.5+1 is incompatible with flutter_svg >=2.0.6.
So, because json_dynamic_widget_plugin_svg depends on both flutter_svg ^2.0.6 and json_dynamic_widget ^6.0.5+1, version solving failed.

```


