### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.1+8] - May 30, 2023
+
+* Automated dependency updates
+
+
 ## [3.0.1+7] - May 9, 2023
 
 * Automated dependency updates
@@ -81,6 +86,7 @@ Updated to `websafe_svg` 3.0.0 which supports different attributes.
 ## [1.0.0] - November 13th, 2021
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,37 +1,39 @@
 name: 'json_dynamic_widget_plugin_svg'
 description: 'A plugin to the JSON Dynamic Widget to provide SVG support to the widgets'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget_plugin_svg'
-version: '3.0.1+7'
+version: '3.0.1+8'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
     - 'lib/**/*.g.dart'
 
-dependencies:
+
+dependencies: 
   child_builder: '^2.0.1'
-  flutter:
+  flutter: 
     sdk: 'flutter'
-  flutter_svg: '^2.0.5'
+  flutter_svg: '^2.0.6'
   json_class: '^2.2.1+3'
-  json_dynamic_widget: '^6.0.5+1'
+  json_dynamic_widget: '^6.0.5+3'
   json_theme: '^5.0.2+6'
-  logging: '^1.1.1'
+  logging: '^1.2.0'
   meta: '^1.7.0'
   uuid: '^3.0.7'
-  websafe_svg: '^3.0.0+5'
+  websafe_svg: '^3.0.0+7'
 
-false_secrets:
+false_secrets: 
   - 'example/web/index.html'
 
-dev_dependencies:
-  flutter_test:
+dev_dependencies: 
+  flutter_test: 
     sdk: 'flutter'
 
-ignore_updates:
+
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `flutter_svg`: 2.0.5 --> 2.0.6
  * `json_dynamic_widget`: 6.0.5+1 --> 6.0.5+3
  * `logging`: 1.1.1 --> 1.2.0
  * `websafe_svg`: 3.0.0+5 --> 3.0.0+7


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ Note: The Google Privacy Policy describes how data is handled in this      ║
  ║ service.                                                                   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
The Flutter CLI developer tool uses Google Analytics to report usage and diagnostic data
along with package dependencies, and crash reporting to send basic crash reports.
This data is used to help improve the Dart platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter --disable-telemetry.
If you opt out of telemetry, an opt-out event will be sent,
and then no further information will be sent.
This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).



Because websafe_svg >=3.0.0+6 depends on http ^1.0.0 and rest_client >=2.2.1+11 depends on http ^0.13.6, websafe_svg >=3.0.0+6 is incompatible with rest_client >=2.2.1+11.
And because json_dynamic_widget >=6.0.5+3 depends on json_schema2 ^2.0.4+8 which depends on rest_client ^2.2.1+11, websafe_svg >=3.0.0+6 is incompatible with json_dynamic_widget >=6.0.5+3.
So, because json_dynamic_widget_plugin_svg depends on both json_dynamic_widget ^6.0.5+3 and websafe_svg ^3.0.0+7, version solving failed.

```


